### PR TITLE
feat: Add Ghostty and iTerm2 support for notifications

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Claudeman Architecture
 
-**Version:** 1.0
-**Last Updated:** 2025-12-04
+**Version:** 1.1
+**Last Updated:** 2026-03-09
 
 ---
 
@@ -49,7 +49,8 @@ Claudeman is a tool that runs Claude Code in a Podman container with custom deve
 │                                                          │
 │  ┌────────────────────┐         ┌──────────────────┐   │
 │  │ Terminal Tab 1     │         │ Terminal Tab 2    │   │
-│  │ (WINID: 30928)     │         │ (WINID: 56974)    │   │
+│  │ (Ghostty/Terminal/ │         │ (Ghostty/Terminal/│   │
+│  │  iTerm2)           │         │  iTerm2)          │   │
 │  │                    │         │                   │   │
 │  │ $ claudeman run    │         │ $ claudeman run   │   │
 │  │                    │         │                   │   │
@@ -76,7 +77,7 @@ Claudeman is a tool that runs Claude Code in a Podman container with custom deve
 │              │ - Parse events │                          │
 │              │ - Show dialog  │                          │
 │              │ - Play audio   │                          │
-│              │ - Focus window │                          │
+│              │ - Focus tab    │                          │
 │              └────────────────┘                          │
 │                                                          │
 └──────────────────────────────────────────────────────────┘
@@ -95,10 +96,18 @@ Claudeman is a tool that runs Claude Code in a Podman container with custom deve
 **Key Responsibilities:**
 
 - Builds/updates the Podman container
-- Captures the Terminal tab ID (WINID) using AppleScript
+- Detects terminal app via `TERM_PROGRAM` and captures terminal-specific ID using AppleScript
 - Copies claudeman scripts into `.claude/claudeman/`
 - Merges hooks into `.claude/settings.json`
 - Runs the container with volume mounts for config and project files
+
+**Supported Terminals:**
+
+| Terminal                                 | `TERM_PROGRAM`   | ID Type           |
+| ---------------------------------------- | ---------------- | ----------------- |
+| [Ghostty](https://ghostty.org/) (1.3.0+) | `ghostty`        | Terminal UUID     |
+| Terminal.app                             | `Apple_Terminal` | Window ID         |
+| [iTerm2](https://iterm2.com/)            | `iTerm.app`      | Session unique ID |
 
 #### 2. `listener.js` (Node.js TCP Server)
 
@@ -107,11 +116,11 @@ Claudeman is a tool that runs Claude Code in a Podman container with custom deve
 **Key Responsibilities:**
 
 - Listens on TCP port 8080
-- Parses three-line protocol: `eventType\nWINID\nmessage\n`
+- Parses four-line protocol: `eventType\nTERM_PROGRAM\nTERM_ID\nmessage\n`
 - Filters out HTTP requests (from network scanners/browsers)
-- Shows macOS dialog with notification
+- Shows macOS dialog with OK/Cancel buttons
 - Plays audio announcement via `say` command
-- Focuses the correct Terminal tab using WINID
+- Focuses the correct terminal tab when user clicks OK
 
 **Event Types:**
 
@@ -119,9 +128,13 @@ Claudeman is a tool that runs Claude Code in a Podman container with custom deve
 - `question` → "❓ needs input" → Audio: "claude-man needs input"
 - `info` → "ℹ️ info" → Audio: "claude-man info"
 
-**Window Focusing:**
+**Tab Focusing:**
 
-Uses AppleScript to find the Terminal window with the given WINID, bring it to the front, and activate the Terminal application.
+Uses AppleScript tailored to each terminal app:
+
+- **Ghostty:** `focus terminal id <UUID>`
+- **Terminal.app:** `set index of (first window whose id is <ID>) to 1`
+- **iTerm2:** Iterates windows/tabs/sessions to find matching `unique id`, then selects
 
 **Protocol Filter:**
 
@@ -137,22 +150,22 @@ The automatic notification system is powered by Claude Code's hook system:
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│ Claude Code Container                                    │
-│                                                          │
-│  ┌──────────────────────────────────────────┐          │
-│  │ hooks.json (auto-invoked by Claude Code) │          │
-│  └────────────┬─────────────────────────────┘          │
-│               │                                          │
+│ Claude Code Container                                   │
+│                                                         │
+│  ┌──────────────────────────────────────────┐           │
+│  │ hooks.json (auto-invoked by Claude Code) │           │
+│  └────────────┬─────────────────────────────┘           │
+│               │                                         │
 │               ├─► PreToolUse(AskUserQuestion)           │
 │               │   → dedup.js → notify.js -t question    │
-│               │                                          │
-│               ├─► PostToolUse(active tools)              │
+│               │                                         │
+│               ├─► PostToolUse(active tools)             │
 │               │   → check-completion.js → notify.js     │
-│               │                                          │
-│               └─► UserPromptSubmit                       │
-│                   → enforce-questions.sh                 │
-│                                                          │
-│  notify.js ──────────► TCP ──────────────────────┐     │
+│               │                                         │
+│               └─► UserPromptSubmit                      │
+│                   → enforce-questions.sh                │
+│                                                         │
+│  notify.js ──────────► TCP ───────────────────────┐     │
 └───────────────────────────────────────────────────┼─────┘
                                                     │
                         ┌───────────────────────────┘
@@ -212,9 +225,14 @@ Runs on container startup to install dependencies. Executes dependencies.sh to s
 - `-m/--message` flag for custom message
 - `-p/--port` flag for custom port (default: 8080)
 
+**Environment Variables:**
+
+- `TERM_PROGRAM` - Terminal program name (ghostty, Apple_Terminal, iTerm.app)
+- `TERM_ID` - Terminal-specific ID for tab focusing
+
 **Protocol:**
 
-Sends three lines over TCP: event type, WINID, and message, each separated by a newline character.
+Sends four lines over TCP: event type, TERM_PROGRAM, TERM_ID, and message, each separated by a newline character.
 
 #### 5. `check-completion.js` (Completion Detector)
 
@@ -225,12 +243,12 @@ Sends three lines over TCP: event type, WINID, and message, each separated by a 
 1. Reads hook input from stdin (JSON with tool_name)
 2. Checks if tool is "active" (Write, Edit, Bash, etc.)
 3. Checks cooldown (15 seconds since last notification)
-4. Updates state file: `/tmp/claudeman-winid-${WINID}.json`
+4. Updates state file: `/tmp/claudeman-termid-${TERM_ID}.json`
 5. Sends completion notification
 
 **State Management:**
 
-- Per-session state using WINID
+- Per-session state using TERM_ID
 - Cooldown prevents notification spam
 - State file tracks `lastNotification` and `lastToolTime`
 
@@ -240,7 +258,7 @@ Sends three lines over TCP: event type, WINID, and message, each separated by a 
 
 **How it works:**
 
-1. Takes lock key as first argument (e.g., `"question-$WINID"`)
+1. Takes lock key as first argument (e.g., `"question-$TERM_ID"`)
 2. Checks for lock file: `/tmp/claudeman-lock-${lockKey}.lock`
 3. If lock exists and age < 2 seconds, skip (duplicate)
 4. Otherwise, create lock and execute command (remaining args)
@@ -281,54 +299,59 @@ When Claude asks a question or completes a task:
 
 1. **Hook fires** (PreToolUse for questions, PostToolUse for completion)
 2. **Hook script runs** (dedup.js → notify.js or check-completion.js → notify.js)
-3. **TCP message sent** to listener: `eventType\nWINID\nmessage\n`
+3. **TCP message sent** to listener: `eventType\nTERM_PROGRAM\nTERM_ID\nmessage\n`
 4. **Listener receives** and parses the message
-5. **macOS notification** shown with emoji and message
+5. **macOS notification** shown with emoji and message (OK/Cancel buttons)
 6. **Audio plays** ("claude-man needs input" or "claude-man task complete")
-7. **User clicks OK** → Terminal tab focused using WINID
+7. **User clicks OK** → Terminal tab focused using appropriate AppleScript for terminal type
 
 ---
 
 ## Multi-Session Support
 
-Claudeman supports running multiple instances simultaneously in different Terminal tabs.
+Claudeman supports running multiple instances simultaneously in different terminal tabs, across different terminal apps.
 
-### How WINID Enables Multi-Session
+### How TERM_ID Enables Multi-Session
 
-**Each terminal tab has:**
+**Each terminal tab has a unique identifier:**
 
-- Unique Window ID (e.g., `30928`, `56974`)
+| Terminal     | ID Format         | Example                                |
+| ------------ | ----------------- | -------------------------------------- |
+| Ghostty      | UUID              | `FBF11A2D-BE3F-45EB-BEFE-94DC37DE29EE` |
+| Terminal.app | Window ID         | `30928`                                |
+| iTerm2       | Session unique ID | `w0t0p0:12345678-ABCD-...`             |
 
 **When `claudeman run` executes:**
 
-1. Script captures front window ID using AppleScript
-2. Container receives WINID as an environment variable
-3. All notifications from that container include the WINID
-4. Listener focuses the correct window when notification is clicked
+1. Script detects terminal via `TERM_PROGRAM` environment variable
+2. Script captures terminal-specific ID using AppleScript
+3. Container receives `TERM_PROGRAM` and `TERM_ID` as environment variables
+4. All notifications from that container include these values
+5. Listener uses appropriate AppleScript to focus the correct tab when OK is clicked
 
 **State Isolation:**
 
-- Lock files: `/tmp/claudeman-lock-question-${WINID}.lock`
-- State files: `/tmp/claudeman-winid-${WINID}.json`
+- Lock files: `/tmp/claudeman-lock-question-${TERM_ID}.lock`
+- State files: `/tmp/claudeman-termid-${TERM_ID}.json`
 
 Each session has independent state, preventing crosstalk between sessions.
 
-### Example: Three Simultaneous Sessions
+### Example: Three Simultaneous Sessions (Mixed Terminals)
 
 ```
-Tab A (WINID: 30928) → Project: website
-Tab B (WINID: 56974) → Project: api-server
-Tab C (WINID: 12345) → Project: mobile-app
+Ghostty Tab (TERM_ID: FBF11A2D-...) → Project: website
+Terminal.app Tab (TERM_ID: 56974)   → Project: api-server
+iTerm2 Tab (TERM_ID: w0t0p0:...)    → Project: mobile-app
 ```
 
-When Tab B's Claude asks a question:
+When the api-server Claude asks a question:
 
-- Notification shows with WINID=56974
+- Notification shows with TERM_PROGRAM=Apple_Terminal, TERM_ID=56974
 - User clicks OK
-- Terminal focuses Tab B (not Tab A or C)
+- Terminal.app focuses the correct tab (not Ghostty or iTerm2)
 - User sees context: `api-server` directory and prompt
 
-**No confusion.** User always lands in the correct project context.
+**No confusion.** User always lands in the correct project context, regardless of terminal app.
 
 ---
 
@@ -386,14 +409,16 @@ project/
 - Sufficient for local host-container communication
 - Easy to implement in both Node.js and shell scripts
 
-### 2. Front Window WINID Capture
+### 2. Terminal Detection via TERM_PROGRAM
 
-**Decision:** Use AppleScript's "front window" to get Terminal window ID
+**Decision:** Use `TERM_PROGRAM` environment variable to detect terminal, then AppleScript to get terminal-specific ID
 **Why:**
 
-- Simple and reliable
-- Each Terminal tab has a unique window ID
+- `TERM_PROGRAM` is a standard env var set by all major terminals
+- No need for System Events to detect frontmost app
+- Each terminal provides a unique ID per tab/session
 - Captures the ID at the moment `claudeman run` is executed
+- Supports multiple terminal apps (Ghostty, Terminal.app, iTerm2)
 
 ### 3. Hook-Based Automation
 
@@ -485,10 +510,11 @@ project/
 
 ### Host Requirements
 
-- **macOS** (for Terminal.app and AppleScript)
+- **macOS** (for AppleScript notifications)
 - **Podman** (container runtime)
 - **Node.js** (for listener.js)
 - **jq** (for JSON manipulation in bash)
+- **Supported terminal:** Ghostty 1.3.0+, Terminal.app, or iTerm2
 
 ### Container Requirements
 
@@ -516,7 +542,7 @@ The system is designed to fail gracefully:
 - **Listener not running**: notify.js fails, but Claude continues working
 - **HTTP requests**: Listener detects and ignores (responds with HTTP 200)
 - **Hook failures**: Claude Code logs error and continues
-- **Invalid WINID**: Notification shows but window focus fails silently
+- **Invalid TERM_ID**: Notification shows but tab focus fails silently
 
 ---
 
@@ -524,7 +550,7 @@ The system is designed to fail gracefully:
 
 - **Listener**: Binds to localhost only, filters HTTP requests
 - **Container**: Runs as non-root `node` user, limited volume mounts
-- **AppleScript**: Requires macOS automation permission (Terminal.app control only)
+- **AppleScript**: Requires macOS automation permission for the terminal app in use (Ghostty, Terminal.app, or iTerm2)
 
 ---
 
@@ -533,11 +559,17 @@ The system is designed to fail gracefully:
 **No notifications?**
 
 - Check if listener.js is running on the host
-- Verify WINID environment variable is set in the container
+- Verify `TERM_PROGRAM` and `TERM_ID` environment variables are set in the container
 
-**Wrong window focused?**
+**Wrong tab focused?**
 
-- Restart container to capture fresh WINID
+- Restart container to capture fresh TERM_ID
+- Ensure you're using a supported terminal (Ghostty 1.3.0+, Terminal.app, or iTerm2)
+
+**Ghostty not focusing correctly?**
+
+- Requires Ghostty 1.3.0 or later for AppleScript support
+- Check Ghostty release notes: https://ghostty.org/docs/install/release-notes/1-3-0
 
 **Too many notifications?**
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,15 @@ In a new tab, start the notification listener:
 claudeman listen
 ```
 
-One listener instance handles all claudeman sessions. Notifications will activate the correct Terminal window for each session automatically.
+One listener instance handles all claudeman sessions. Notifications will activate the correct terminal tab for each session automatically.
+
+### Supported Terminals
+
+| Terminal                        | Minimum Version | Notes                                                                                |
+| ------------------------------- | --------------- | ------------------------------------------------------------------------------------ |
+| [Ghostty](https://ghostty.org/) | 1.3.0+          | Requires [AppleScript support](https://ghostty.org/docs/install/release-notes/1-3-0) |
+| Terminal.app                    | Any             | Built-in macOS terminal                                                              |
+| [iTerm2](https://iterm2.com/)   | Any             | Popular third-party terminal                                                         |
 
 ## Features
 
@@ -120,6 +128,7 @@ The included `hooks.json` provides hooks for:
 - [Podman CLI](https://podman.io/)
 - macOS (for audio notifications; optional)
 - Node.js (for listener; optional)
+- Supported terminal: Ghostty 1.3.0+, Terminal.app, or iTerm2 (for tab focusing; optional)
 
 ## Architecture
 

--- a/claudeman
+++ b/claudeman
@@ -40,13 +40,33 @@ function run_container {
     local cmd=${1:-""}  # Command to run (optional)
 
     # Common environment variables
-    # Get the current Terminal window ID where claude-code is running interactively, and assign to a shell variable
-    local winid=$(osascript -e 'tell application "Terminal" to id of front window')
+    # Get terminal-specific ID for notifications based on TERM_PROGRAM
+    local term_id=""
+
+    case "${TERM_PROGRAM:-}" in
+        ghostty)
+            # Get terminal UUID (unique per tab/pane)
+            term_id=$(osascript -e 'tell application "Ghostty" to get id of focused terminal of selected tab of front window' 2>/dev/null | sed 's/terminal id //')
+            ;;
+        Apple_Terminal)
+            # Get window ID (unique per tab in Terminal.app)
+            term_id=$(osascript -e 'tell application "Terminal" to id of front window' 2>/dev/null)
+            ;;
+        iTerm.app)
+            # Get session unique ID
+            term_id=$(osascript -e 'tell application "iTerm2" to get unique id of current session of current window' 2>/dev/null)
+            ;;
+        *)
+            echo "Warning: Unsupported terminal '${TERM_PROGRAM:-unknown}'. Notifications may not focus correctly."
+            ;;
+    esac
+
     local env_vars=(
         "-e NODE_OPTIONS=--max-old-space-size=4096"
         "-e CLAUDE_CONFIG_DIR=/home/node/.claude"
         "-e POWERLEVEL9K_DISABLE_GITSTATUS=true"
-        "-e WINID=$winid"
+        "-e TERM_PROGRAM=${TERM_PROGRAM:-}"
+        "-e TERM_ID=$term_id"
     )
     if [[ -n ${RUNTIME_PATH:-} ]]; then
         env_vars+=(

--- a/lib/check-completion.js
+++ b/lib/check-completion.js
@@ -34,9 +34,9 @@ process.stdin.on("end", () => {
       process.exit(0);
     }
 
-    // Use WINID for per-session state (each terminal window = unique session)
-    const winid = process.env.WINID || "default";
-    const stateFile = `/tmp/claudeman-winid-${winid}.json`;
+    // Use TERM_ID for per-session state (each terminal tab = unique session)
+    const termId = process.env.TERM_ID || "default";
+    const stateFile = `/tmp/claudeman-termid-${termId}.json`;
 
     let state = { lastNotification: 0, lastToolTime: 0 };
     if (fs.existsSync(stateFile)) {

--- a/lib/dedup.js
+++ b/lib/dedup.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Deduplication wrapper for notification commands
 // Usage: node dedup.js "lock-key" command [args...]
-// Example: node dedup.js "question-$WINID" node notify.js -t question -m "msg"
+// Example: node dedup.js "question-$TERM_ID" node notify.js -t question -m "msg"
 
 const fs = require("fs");
 const { spawn } = require("child_process");

--- a/lib/hooks.json
+++ b/lib/hooks.json
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node /home/node/.claude/claudeman/dedup.js \"question-$WINID\" node /home/node/.claude/claudeman/notify.js -t question -m \"Question ready\""
+            "command": "node /home/node/.claude/claudeman/dedup.js \"question-$TERM_ID\" node /home/node/.claude/claudeman/notify.js -t question -m \"Question ready\""
           }
         ]
       }

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -1,4 +1,4 @@
-// TCP listener that accepts a three-line payload: eventType, WINID, message.
+// TCP listener that accepts a four-line payload: eventType, TERMINAL_APP, TERMINAL_ID, message.
 // Responds "received", logs to stderr, and triggers macOS notifications via osascript.
 //
 // Usage:
@@ -13,9 +13,20 @@
 //   -v, --volume   Audio volume 0-100, or "auto" to not adjust (default: auto)
 //                  Note: Setting 0-100 overrides system mute
 //
+// Payload format (newline-separated):
+//   Line 1: eventType (complete, question, idle, info)
+//   Line 2: TERM_PROGRAM (ghostty, Apple_Terminal)
+//   Line 3: TERM_ID (terminal UUID for Ghostty, window ID for Terminal)
+//   Line 4+: message (may span multiple lines)
+//
+// Supported terminals:
+//   - ghostty: Uses AppleScript to focus Ghostty terminal by UUID
+//   - Apple_Terminal: Uses AppleScript to focus Terminal.app window by ID
+//   - iTerm.app: Uses AppleScript to focus iTerm2 session by unique ID
+//
 // Notes:
 // - Requires macOS for osascript behavior.
-// - WINID is provided by the client as the second line. If absent, AppleScript skips window focusing.
+// - Dialog shows OK/Cancel buttons; terminal is focused only when OK is clicked.
 // - Press Ctrl+C to stop.
 
 const net = require("net");
@@ -67,10 +78,11 @@ const server = net.createServer((socket) => {
       return;
     }
 
-    // Split into lines: eventType, WINID, message
+    // Split into lines: eventType, TERM_PROGRAM, TERM_ID, message
     const lines = buffer.replace(/\r\n/g, "\n").split("\n");
     const eventType = (lines.shift() || "").trim() || "complete";
-    const WINID = (lines.shift() || "").trim();
+    const TERM_PROGRAM = (lines.shift() || "").trim();
+    const TERM_ID = (lines.shift() || "").trim();
     const RECEIVED_MESSAGE = lines.join("\n").trim();
 
     // Respond to client and close
@@ -78,12 +90,14 @@ const server = net.createServer((socket) => {
       socket.end();
     });
 
-    // Log event type and WINID to stderr
+    // Log event type and terminal info to stderr
     process.stderr.write(`Event type: '${eventType}'\n`);
-    if (WINID) {
-      process.stderr.write(`WINID='${WINID}'\n`);
+    if (TERM_PROGRAM) {
+      process.stderr.write(
+        `Terminal: ${TERM_PROGRAM} (ID: ${TERM_ID || "none"})\n`,
+      );
     } else {
-      process.stderr.write("WINID not provided\n");
+      process.stderr.write("TERM_PROGRAM not provided\n");
     }
 
     // Map event type to label and emoji
@@ -124,14 +138,44 @@ const server = net.createServer((socket) => {
       );
     }
 
-    // Build AppleScript. If WINID is numeric, we focus the Terminal window by id; otherwise skip focusing.
-    const focusTerminalScript =
-      WINID && /^\d+$/.test(WINID)
-        ? `tell application "Terminal"
-           set index of (first window whose id is ${WINID}) to 1
-           activate
-         end tell`
-        : "";
+    // Build AppleScript to focus the terminal based on TERM_PROGRAM
+    // Focus happens AFTER user clicks OK in the dialog
+    let focusTerminalScript = "";
+    if (TERM_PROGRAM === "ghostty" && TERM_ID) {
+      focusTerminalScript = `
+        tell application "Ghostty"
+          activate
+          focus terminal id "${TERM_ID}"
+        end tell`;
+    } else if (
+      TERM_PROGRAM === "Apple_Terminal" &&
+      TERM_ID &&
+      /^\d+$/.test(TERM_ID)
+    ) {
+      focusTerminalScript = `
+        tell application "Terminal"
+          set index of (first window whose id is ${TERM_ID}) to 1
+          activate
+        end tell`;
+    } else if (TERM_PROGRAM === "iTerm.app" && TERM_ID) {
+      // iTerm2: find session by unique ID and focus it
+      focusTerminalScript = `
+        tell application "iTerm2"
+          repeat with w in windows
+            repeat with t in tabs of w
+              repeat with s in sessions of t
+                if unique id of s is "${TERM_ID}" then
+                  select s
+                  select t
+                  select w
+                  activate
+                  return
+                end if
+              end repeat
+            end repeat
+          end repeat
+        end tell`;
+    }
 
     // Build volume control script based on VOLUME setting
     const volumeScript =
@@ -142,12 +186,16 @@ const server = net.createServer((socket) => {
       say "${announcement}"
       set volume output volume oldVolume`;
 
+    // Dialog with OK/Cancel - Cancel silently exits, OK focuses terminal
+    const dialogScript = `
+      set dialogResult to display dialog "${escapeForAppleScript(message)}" with icon note buttons {"Cancel", "OK"} default button "OK"
+      if button returned of dialogResult is "OK" then
+        ${focusTerminalScript}
+      end if`;
+
     const osaScript = `
       ${volumeScript}
-      tell application "Terminal" to display dialog "${escapeForAppleScript(
-        message,
-      )}" with icon note buttons {"OK"} default button "OK"
-      ${focusTerminalScript}
+      ${dialogScript}
     `;
 
     // Run osascript asynchronously; do not block the server

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -10,6 +10,10 @@
 //   -t, --type     Event type: complete, question, idle, info (default: complete)
 //   -m, --message  Notification message (default: "Task complete")
 //   -p, --port     Listener port (default: 8080)
+//
+// Environment variables (set by claudeman):
+//   TERM_PROGRAM   Terminal program (ghostty, Apple_Terminal)
+//   TERM_ID        Terminal-specific ID for focusing (UUID for Ghostty, window ID for Terminal)
 
 const net = require("net");
 
@@ -34,10 +38,11 @@ for (let i = 0; i < args.length; i++) {
   }
 }
 
-const WINID = process.env.WINID || "";
+const TERM_PROGRAM = process.env.TERM_PROGRAM || "";
+const TERM_ID = process.env.TERM_ID || "";
 
 const timeoutMs = 2000; // 2s timeout similar to `nc -w 1`/`timeout 2`
-const payload = `${eventType}\n${WINID}\n${message}\n`;
+const payload = `${eventType}\n${TERM_PROGRAM}\n${TERM_ID}\n${message}\n`;
 
 console.log(
   `Triggering listener at ${HOST}:${port} with message: '${message}'`,


### PR DESCRIPTION
closes #2

Support multiple terminal apps for tab focusing when notifications are clicked. Uses TERM_PROGRAM to detect terminal and TERM_ID for tab identification.

Supported terminals:
- Ghostty 1.3.0+ (focus by terminal UUID)
- Terminal.app (focus by window ID)
- iTerm2 (focus by session ID)

Also adds OK/Cancel dialog buttons - terminal only focuses on OK click.