### PR TITLE
fix: Remove volume control from listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,9 @@ claudeman hooks                                # List available hooks
 
 ### Listen Options
 
-| Flag                         | Description                                              |
-| ---------------------------- | -------------------------------------------------------- |
-| `-p, --port <port>`          | Listener port (default: 8080)                            |
-| `-v, --volume <0-100\|auto>` | Audio volume (default: auto). Note: 0-100 overrides mute |
+| Flag                | Description                   |
+| ------------------- | ----------------------------- |
+| `-p, --port <port>` | Listener port (default: 8080) |
 
 ## Audio Notifications
 

--- a/claudeman
+++ b/claudeman
@@ -286,8 +286,6 @@ function usage {
     echo ""
     echo "Listen Options:"
     echo "  -p, --port <port>        Listener port (default: 8080)"
-    echo "  -v, --volume <0-100|auto>  Audio volume (default: auto)"
-    echo "                           Note: Setting 0-100 overrides system mute"
     echo ""
     echo "Examples:"
     echo "  claudeman run                                  # Minimal (no deps, no hooks)"
@@ -436,16 +434,11 @@ case $command in
     listen)
         # Parse listen flags
         PORT=8080
-        VOLUME=auto
 
         while [[ $# -gt 0 ]]; do
             case $1 in
                 -p|--port)
                     PORT="$2"
-                    shift 2
-                    ;;
-                -v|--volume)
-                    VOLUME="$2"
                     shift 2
                     ;;
                 *)
@@ -466,9 +459,9 @@ case $command in
             echo "Error: listener.js not found at $LIB_DIR/listener.js"
             exit 1
         fi
-        echo "Starting notification listener on port $PORT (volume: $VOLUME)..."
+        echo "Starting notification listener on port $PORT..."
         echo "Press Ctrl+C to stop"
-        node "$LIB_DIR/listener.js" -p "$PORT" -v "$VOLUME"
+        node "$LIB_DIR/listener.js" -p "$PORT"
         ;;
     deps)
         echo "Available dependencies:"

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -2,16 +2,11 @@
 // Responds "received", logs to stderr, and triggers macOS notifications via osascript.
 //
 // Usage:
-//   node listener.js                   // default port 8080, volume auto
+//   node listener.js                   // default port 8080
 //   node listener.js -p 9000           // custom port
-//   node listener.js -v 80             // custom volume (0-100)
-//   node listener.js -v auto           // don't adjust volume (default)
-//   node listener.js -p 9000 -v 60     // both options
 //
 // Flags:
 //   -p, --port     Listener port (default: 8080)
-//   -v, --volume   Audio volume 0-100, or "auto" to not adjust (default: auto)
-//                  Note: Setting 0-100 overrides system mute
 //
 // Payload format (newline-separated):
 //   Line 1: eventType (complete, question, idle, info)
@@ -35,23 +30,19 @@ const { spawn } = require("child_process");
 // Parse flags
 const args = process.argv.slice(2);
 let PORT = 8080;
-let VOLUME = "auto"; // 0-100, or "auto" to not adjust (default: auto)
 
 for (let i = 0; i < args.length; i++) {
   const arg = args[i];
 
   if (arg === "-p" || arg === "--port") {
     PORT = parseInt(args[++i], 10);
-  } else if (arg === "-v" || arg === "--volume") {
-    const val = args[++i];
-    VOLUME = val === "auto" ? "auto" : parseInt(val, 10);
   } else if (/^\d+$/.test(arg)) {
     // Backward compatibility: positional port argument
     PORT = parseInt(arg, 10);
   }
 }
 
-console.log(`Starting listener on port ${PORT} (volume: ${VOLUME})...`);
+console.log(`Starting listener on port ${PORT}...`);
 console.log("Press Ctrl+C to stop\n");
 
 const server = net.createServer((socket) => {
@@ -177,15 +168,6 @@ const server = net.createServer((socket) => {
         end tell`;
     }
 
-    // Build volume control script based on VOLUME setting
-    const volumeScript =
-      VOLUME === "auto"
-        ? `say "${announcement}"` // Don't adjust volume
-        : `set oldVolume to output volume of (get volume settings)
-      set volume output volume ${VOLUME}
-      say "${announcement}"
-      set volume output volume oldVolume`;
-
     // Dialog with OK/Cancel - Cancel silently exits, OK focuses terminal
     const dialogScript = `
       set dialogResult to display dialog "${escapeForAppleScript(message)}" with icon note buttons {"Cancel", "OK"} default button "OK"
@@ -194,7 +176,7 @@ const server = net.createServer((socket) => {
       end if`;
 
     const osaScript = `
-      ${volumeScript}
+      say "${announcement}"
       ${dialogScript}
     `;
 
@@ -226,7 +208,7 @@ server.on("error", (err) => {
 });
 
 server.listen(PORT, () => {
-  // Periodic log similar to the shell script’s while loop echo
+  // Periodic log similar to the shell script's while loop echo
   logTick();
 });
 


### PR DESCRIPTION
Volume adjustment caused audio to route to speakers instead of headphones. Let the OS handle audio volume and routing instead.