### PR TITLE
fix(deps): add USER root switching for system-level installs

### DIFF
--- a/lib/deps/go.cf
+++ b/lib/deps/go.cf
@@ -3,6 +3,9 @@
 
 ARG TARGETARCH
 
+# Switch to root for system-level install
+USER root
+
 # Install Go
 RUN curl -fsSL "https://go.dev/dl/go1.24.3.linux-${TARGETARCH}.tar.gz" -o /tmp/go.tgz \
     && tar -C /usr/local -xzf /tmp/go.tgz \
@@ -11,6 +14,9 @@ RUN curl -fsSL "https://go.dev/dl/go1.24.3.linux-${TARGETARCH}.tar.gz" -o /tmp/g
 ENV PATH="/usr/local/go/bin:/home/node/go/bin:${PATH}"
 ENV GOPATH="/home/node/go"
 
-# Install Go tools
+# Switch back to node for user-level installs
+USER node
+
+# Install Go tools (as node user, installs to $GOPATH)
 RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.0 \
     && go install golang.org/x/tools/cmd/goimports@latest

--- a/lib/deps/whitespace-tools.cf
+++ b/lib/deps/whitespace-tools.cf
@@ -1,7 +1,16 @@
 # Whitespace tools (newline, trailingspace)
 # Install whitespace-tools from pre-built binaries
+
+ARG TARGETARCH
+
+# Ensure bin directory exists
+RUN mkdir -p /home/node/go/bin
+
+# Install whitespace-tools
 RUN curl -fsSL "https://github.com/scottrigby/whitespace-tools/releases/download/v1.0.1/whitespace-tools_1.0.1_linux_${TARGETARCH}.tar.gz" -o /tmp/ws.tgz \
     && tar -C /tmp -xzf /tmp/ws.tgz \
     && mv /tmp/newline /tmp/trailingspace /home/node/go/bin/ \
     && chmod +x /home/node/go/bin/newline /home/node/go/bin/trailingspace \
     && rm /tmp/ws.tgz
+
+ENV PATH="/home/node/go/bin:${PATH}"


### PR DESCRIPTION
Fixes a regression where go.cf was failing with "Permission denied" when extracting to /usr/local because because upstream Dockerfile runs as node user.