### PR TITLE
feat: add curl-based installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,22 +36,27 @@ Claudeman solves this by:
 
 ## Installation
 
-Homebrew (recommended):
+Homebrew:
 
 ```bash
 brew install scottrigby/tap/claudeman
 ```
 
-Or clone this repository and symlink the script globally:
+One-liner install:
 
 ```bash
-git clone https://github.com/scottrigby/claudeman ~/claudeman
-sudo ln -s ~/claudeman/claudeman /usr/local/bin/claudeman
+curl -fsSL https://raw.githubusercontent.com/scottrigby/claudeman/main/install.sh | bash
 ```
 
-## Usage
+Install from a specific branch:
 
-From any project directory, simply run:
+```bash
+curl -fsSL https://raw.githubusercontent.com/scottrigby/claudeman/main/install.sh | BRANCH=my-branch bash
+```
+
+To update, re-run the install command.
+
+## Quick Start
 
 ```bash
 claudeman run

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRANCH="${BRANCH:-main}"
+LOCAL="${LOCAL:-}"
+INSTALL_DIR="$HOME/.claudeman"
+REPO_URL="https://github.com/scottrigby/claudeman.git"
+SYMLINK_PATH="/usr/local/bin/claudeman"
+
+info() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+error() { printf '\033[1;31mError:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# Check prerequisites
+command -v git >/dev/null 2>&1 || error "git is required but not installed"
+command -v node >/dev/null 2>&1 || error "Node.js is required but not installed"
+
+NODE_MAJOR=$(node -p 'process.versions.node.split(".")[0]')
+[ "$NODE_MAJOR" -ge 18 ] 2>/dev/null || error "Node.js 18+ is required (found $(node --version))"
+
+# Local mode: copy from a local repo instead of cloning from GitHub
+if [ -n "$LOCAL" ]; then
+  LOCAL="$(cd "$LOCAL" && pwd)"
+  [ -d "$LOCAL/.git" ] || error "$LOCAL is not a git repository"
+  info "Installing from local repo: $LOCAL (branch: $BRANCH)..."
+  if [ -d "$INSTALL_DIR" ]; then
+    rm -rf "$INSTALL_DIR"
+  fi
+  git clone --branch "$BRANCH" "$LOCAL" "$INSTALL_DIR"
+elif [ -d "$INSTALL_DIR/.git" ]; then
+  info "Updating existing installation..."
+  git -C "$INSTALL_DIR" fetch --all --prune
+  git -C "$INSTALL_DIR" checkout "$BRANCH"
+  git -C "$INSTALL_DIR" pull --ff-only origin "$BRANCH"
+else
+  if [ -d "$INSTALL_DIR" ]; then
+    error "$INSTALL_DIR already exists but is not a git repo. Remove it first."
+  fi
+  info "Cloning claudeman (branch: $BRANCH)..."
+  git clone --branch "$BRANCH" "$REPO_URL" "$INSTALL_DIR"
+fi
+
+# Install dependencies
+info "Installing dependencies..."
+(cd "$INSTALL_DIR" && npm install --no-fund --no-audit)
+
+# Symlink
+info "Creating symlink at $SYMLINK_PATH..."
+if [ -w "$(dirname "$SYMLINK_PATH")" ]; then
+  ln -sf "$INSTALL_DIR/claudeman" "$SYMLINK_PATH"
+else
+  sudo ln -sf "$INSTALL_DIR/claudeman" "$SYMLINK_PATH"
+fi
+
+# Success
+VERSION=$("$SYMLINK_PATH" --version 2>/dev/null || echo "unknown")
+info "claudeman $VERSION installed successfully!"
+echo ""
+echo "  Get started:"
+echo "    claudeman help"
+echo "    claudeman init"
+echo ""
+echo "  To update, re-run this installer."


### PR DESCRIPTION
## Summary
- Adds `install.sh` — a one-liner curl installer that clones the repo and symlinks `claudeman` into PATH
- Supports installing from a specific branch via `BRANCH=my-branch`
- Updates README with new install instructions

## Test plan
- [ ] Run `curl -fsSL https://raw.githubusercontent.com/scottrigby/claudeman/main/install.sh | bash` on a clean machine
- [ ] Verify `claudeman` is available on PATH after install
- [ ] Test `BRANCH=<branch> bash` variant
- [ ] Re-run install to verify update path works

🤖 Generated with [Claude Code](https://claude.com/claude-code)