### PR TITLE
feat: add -e/--environment flag for container env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ claudeman run                                  # Minimal (no deps, no hooks)
 claudeman run --deps=go --hooks=prettier       # Go + prettier formatting
 claudeman run --hooks=prettier,questions       # Prettier + notifications
 claudeman run --deps=all --hooks=all           # Everything
+claudeman run -e GH_TOKEN=xxx                   # With env var
 claudeman run -- bash                          # Shell access
 claudeman listen                               # Start notification listener
 claudeman deps                                 # List available deps
@@ -85,12 +86,25 @@ claudeman hooks                                # List available hooks
 | --------------- | ------------------------------------------------------- |
 | `--deps=DEPS`   | Dependencies to install (go,python,rust,playwright,all) |
 | `--hooks=HOOKS` | Hooks to enable (prettier,gofmt,q-notify,q-enforce,all) |
+| `-e, --environment K=V` | Pass env var to container (repeatable) |
 
 ### Listen Options
 
 | Flag                | Description                   |
 | ------------------- | ----------------------------- |
 | `-p, --port <port>` | Listener port (default: 8080) |
+
+## Environment Variables
+
+Pass environment variables into the container with `-e` (repeatable):
+
+```bash
+claudeman run -e GH_TOKEN=ghp_xxx                    # Explicit value
+claudeman run -e GH_TOKEN                             # Pass through from host
+claudeman run -e GH_TOKEN=xxx -e NPM_TOKEN=yyy        # Multiple vars
+```
+
+This is useful for credentials needed inside the container (e.g., GitHub PATs for cloning private repos). Variables passed with `-e KEY` (no value) inherit the value from the host environment.
 
 ## Audio Notifications
 

--- a/claudeman
+++ b/claudeman
@@ -246,6 +246,15 @@ function run_container {
         "-e TERM_ID=$term_id"
     )
 
+    # Append user-provided environment variables
+    for user_env in "${USER_ENV_VARS[@]}"; do
+        if [[ "$user_env" == *=* ]]; then
+            env_vars+=("-e $user_env")
+        else
+            env_vars+=("-e ${user_env}=${!user_env:-}")
+        fi
+    done
+
     # Common volume mounts
     local volumes=(
         "-v $(pwd)/.claude:/home/node/.claude"
@@ -282,6 +291,8 @@ function usage {
     echo "  --hooks=HOOKS            Hooks to enable (comma-separated)"
     echo "                           Examples: --hooks=prettier  --hooks=prettier,questions  --hooks=all"
     echo "                           Default: none"
+    echo "  -e, --environment K=V    Pass environment variable to container (repeatable)"
+    echo "                           Examples: -e GH_TOKEN=xxx  -e GH_TOKEN (from host)"
     echo "  --                       Separator between options and command"
     echo ""
     echo "Listen Options:"
@@ -292,6 +303,7 @@ function usage {
     echo "  claudeman run --deps=go --hooks=prettier       # Go + prettier hook"
     echo "  claudeman run --hooks=prettier,q-notify       # Prettier + question notifications"
     echo "  claudeman run --deps=all --hooks=all           # Everything"
+    echo "  claudeman run -e GH_TOKEN=xxx                   # With env var"
     echo "  claudeman run -- bash                          # Shell access"
     echo "  claudeman listen                               # Start notification listener"
     echo "  claudeman deps                                 # List available deps"
@@ -329,6 +341,7 @@ case $command in
         # Parse run flags (before --)
         SELECTED_DEPS=""
         SELECTED_HOOKS=""
+        USER_ENV_VARS=()
 
         while [[ $# -gt 0 ]]; do
             case $1 in
@@ -339,6 +352,14 @@ case $command in
                 --hooks=*)
                     SELECTED_HOOKS="${1#--hooks=}"
                     shift
+                    ;;
+                -e|--environment)
+                    if [[ -z "${2:-}" ]]; then
+                        echo "Error: $1 requires a KEY=VALUE argument"
+                        exit 1
+                    fi
+                    USER_ENV_VARS+=("$2")
+                    shift 2
                     ;;
                 --)
                     shift


### PR DESCRIPTION
## Summary

- Adds repeatable `-e, --environment KEY=VALUE` flag to pass environment variables into the container
- Supports explicit values (`-e GH_TOKEN=xxx`) and host passthrough (`-e GH_TOKEN`)
- Matches docker/podman conventions for familiarity

## Motivation

Users can't pass custom environment variables (e.g., GitHub PATs, NPM tokens) into the claudeman container, blocking workflows like cloning private repos. This fits the container security model where "credentials must be explicitly mounted."

## Changes

- **`claudeman`**: Flag parsing, env var injection in `run_container()`, updated help text
- **`README.md`**: Run Options table, examples, new "Environment Variables" section

## Test plan

- [ ] `claudeman help` — verify `-e` flag appears in help
- [ ] `claudeman run -e TEST_VAR=hello -- env | grep TEST_VAR` — basic env var
- [ ] `claudeman run -e VAR1=one -e VAR2=two -- env | grep -E 'VAR1|VAR2'` — multiple vars
- [ ] `export MY_SECRET=hunter2 && claudeman run -e MY_SECRET -- env | grep MY_SECRET` — host passthrough
- [ ] `claudeman run -e` — error case (should print error and exit 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)