### PR TITLE
feat(profiles): add k8s profile for Kubernetes development

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -95,6 +95,37 @@ causing plugins and hooks to appear duplicated.
 Note: claudeman's own `--scope global` (host `~/.config/claudeman/`) is for
 claudeman profiles, not Claude Code config. It persists on the host independently.
 
+### Sensitive files in `.claude-config/`
+
+`.claude-config/` is gitignored and already contains OAuth credentials. It is
+the recommended location for any sensitive per-project files that Claude needs
+inside the container (e.g., kubeconfig, cloud credentials). Since it's already
+bind-mounted, no additional mount configuration is needed — just place the file
+and set the corresponding env var via `--env`.
+
+## Kubernetes Profile (`k8s`)
+
+The `k8s` profile installs kubectl and Helm via the
+`kubectl-helm-minikube` devcontainer feature (with minikube disabled).
+
+**Kubeconfig isolation:** Users export a single cluster context into
+`.claude-config/kubeconfig` using `kubectl config view --minify --flatten`.
+This avoids exposing the full `~/.kube/config` (which may contain credentials
+for unrelated clusters) and keeps the file gitignored. See `profiles/k8s.md`.
+
+**Container access to local clusters:** Local cluster API servers (Kind,
+minikube) listen on `127.0.0.1`, which doesn't resolve inside the container.
+The exported kubeconfig rewrites the address to `host.containers.internal`
+(Podman's host bridge, already in the firewall allowlist). TLS verification
+is skipped for local clusters since their certs are issued for `127.0.0.1`.
+Remote clusters (EKS, GKE, etc.) work without modification — their API server
+addresses are public hostnames, added via `--extra-domains`.
+
+**Firewall domains:** The profile whitelists Helm chart registries
+(`charts.bitnami.com`, `charts.jetstack.io`, etc.) and documentation sites.
+Registries that support OCI (e.g., Bitnami via `registry-1.docker.io`) are
+preferred, but HTTP chart repos are included as an example for charts that don't offer OCI.
+
 ## Firewall Domains
 
 The upstream devcontainer runs `init-firewall.sh` which blocks all outbound

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,15 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for design context.
 
 ---
 
+## Mounts
+
+- [ ] Custom mount support in profiles — `mounts` field for additional bind
+      mounts (e.g., `~/.kube` for kubectl access, `~/.aws` for AWS CLI).
+      Currently workaround is placing files in `.claude-config/` (already
+      mounted) and setting env vars via `--env`.
+
+---
+
 ## Hooks
 
 - [ ] `hook add/remove/list` — manage hooks in profiles, same pattern as

--- a/profiles/k8s.json
+++ b/profiles/k8s.json
@@ -1,0 +1,23 @@
+{
+  "name": "k8s",
+  "description": "Kubernetes development with kubectl and Helm",
+  "features": {
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+      "kubectl": "latest",
+      "helm": "latest",
+      "minikube": "none"
+    }
+  },
+  "extraDomains": [
+    "kubernetes.io",
+    "helm.sh",
+    "artifacthub.io",
+    "charts.bitnami.com",
+    "registry-1.docker.io",
+    "charts.jetstack.io",
+    "traefik.github.io",
+    "doc.traefik.io",
+    "cert-manager.io",
+    "cloudnative-pg.github.io"
+  ]
+}

--- a/profiles/k8s.md
+++ b/profiles/k8s.md
@@ -1,0 +1,55 @@
+# k8s Profile
+
+Installs kubectl and Helm for Kubernetes development inside claudeman.
+
+## Kubeconfig Setup
+
+Export a single cluster context securely into `.claude-config/` (gitignored, already mounted):
+
+```bash
+# Export a specific context (replace CONTEXT_NAME with your context)
+kubectl config view --minify --flatten --context=CONTEXT_NAME > .claude-config/kubeconfig
+```
+
+### Container access
+
+The kubeconfig API server address must be reachable from inside the container.
+For local clusters (Kind, minikube, etc.), replace `127.0.0.1` with
+`host.containers.internal` (Podman's bridge to the host):
+
+```bash
+CONTEXT_NAME=kind-k8laude
+kubectl config view --minify --flatten --context=$CONTEXT_NAME \
+  | sed -e 's/127.0.0.1/host.containers.internal/g' \
+        -e 's/certificate-authority-data:.*/insecure-skip-tls-verify: true/' \
+  > .claude-config/kubeconfig
+```
+
+`insecure-skip-tls-verify` is needed because local cluster certs are issued
+for `127.0.0.1`, not `host.containers.internal`. For remote clusters (EKS,
+GKE, etc.) this isn't needed — the API server address is already a public
+hostname.
+
+### Firewall
+
+The API server hostname must be whitelisted. `host.containers.internal` is
+already allowed by claudeman. For remote clusters, add the domain:
+
+```bash
+claudeman run --profile=k8s \
+  --extra-domains your-cluster.region.eks.amazonaws.com \
+  --env KUBECONFIG=/workspace/.claude-config/kubeconfig
+```
+
+## Usage
+
+```bash
+claudeman run --profile=k8s \
+  --env KUBECONFIG=/workspace/.claude-config/kubeconfig
+```
+
+## What's installed
+
+- `kubectl` (latest)
+- `helm` (latest)
+- Firewall domains for K8s and Helm doc sites, ArtifactHub for chart and plugin discovery, example chart registries


### PR DESCRIPTION
Installs kubectl + Helm via devcontainer feature (minikube disabled). Whitelists Helm chart registries, K8s docs, and cert-manager/traefik domains. Includes setup docs for secure kubeconfig export to .claude-config/ with single-context isolation.