### PR TITLE
fix(firewall): support raw IP addresses in --extra-domains

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,19 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for design context.
 
 ---
 
+## Firewall
+
+- [ ] Wildcard domain resolution — support `*.example.com` in `extraDomains`
+      so all subdomains are whitelisted without listing each one individually.
+      Use case: `*.ingress.replicatedcluster.com` for CMX cluster access.
+- [ ] Raw IP support in `extraDomains` — detect IPs and add to ipset directly
+      instead of running `dig` (which fails on IPs and crashes the firewall).
+- [ ] Abstract OAuth listener proxy — generalize the browser-open relay to
+      support any CLI tool's OAuth flow (e.g., `replicated login`) inside
+      containers, not just Claude Code's `/login`.
+
+---
+
 ## Mounts
 
 - [ ] Custom mount support in profiles — `mounts` field for additional bind

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,11 +34,6 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for design context.
 - [ ] Wildcard domain resolution — support `*.example.com` in `extraDomains`
       so all subdomains are whitelisted without listing each one individually.
       Use case: `*.ingress.replicatedcluster.com` for CMX cluster access.
-- [ ] Raw IP support in `extraDomains` — detect IPs and add to ipset directly
-      instead of running `dig` (which fails on IPs and crashes the firewall).
-- [ ] Abstract OAuth listener proxy — generalize the browser-open relay to
-      support any CLI tool's OAuth flow (e.g., `replicated login`) inside
-      containers, not just Claude Code's `/login`.
 
 ---
 
@@ -69,6 +64,15 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for design context.
 - [ ] Voice mode in containers — mic access requires audio socket
       passthrough or host-side proxy via `claudeman listen`.
       See https://code.claude.com/docs/en/voice-dictation
+
+---
+
+## Auth
+
+
+- [ ] Abstract OAuth listener proxy — generalize the browser-open relay to
+      support any CLI tool's OAuth flow (e.g., `replicated login`) inside
+      containers, not just Claude Code's `/login`.
 
 ---
 

--- a/patches/.devcontainer/init-firewall.sh
+++ b/patches/.devcontainer/init-firewall.sh
@@ -97,13 +97,20 @@ done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q 2>/de
 # This initial resolution fails loudly on misconfigured domains (exit 1).
 # The background refresh script below tolerates transient DNS failures silently.
 for domain in "${DYNAMIC_DOMAINS[@]}"; do
+    # Raw IPs: add directly, skip DNS resolution
+    if [[ "$domain" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+        echo "Adding IP $domain directly..."
+        ipset add "$IPSET_DYNAMIC" "$domain" timeout "$DNS_TTL" -exist
+        continue
+    fi
+
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
     if [ -z "$ips" ]; then
         echo "ERROR: Failed to resolve $domain"
         exit 1
     fi
-    
+
     while read -r ip; do
         if [[ ! "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             echo "ERROR: Invalid IP from DNS for $domain: $ip"
@@ -151,6 +158,11 @@ DNS_TTL=$DNS_TTL
 
 # Domain list passed as arguments
 for domain in "\$@"; do
+    # Raw IPs: re-add directly, skip DNS
+    if [[ "\$domain" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\$ ]]; then
+        ipset add "\$IPSET_DYNAMIC" "\$domain" timeout "\$DNS_TTL" -exist 2>/dev/null
+        continue
+    fi
     ips=\$(dig +short A "\$domain" 2>/dev/null | grep -E '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\$')
     if [ -n "\$ips" ]; then
         while IFS= read -r ip; do


### PR DESCRIPTION
keeping in sync with claude-code upstream PR: `https://github.com/anthropics/claude-code/pull/40322`

init-firewall.sh exits 1 when EXTRA_DOMAINS contains a raw IP address because dig cannot resolve IPs. Detect IPv4 addresses and add them directly to the dynamic ipset, skipping DNS resolution. Also handle IPs in the background refresh script.

Also renames internally set WHITELIST_DOMAINS to EXTRA_DOMAINS. Matches upstream claude-code PR rename. Note this rename is backwards-compatible - the env var is an internal implementation detail between run.js and the devcontainer firewall script. Users interact via --extra-domains flag and profile extraDomains field, which are unchanged.