### PR TITLE
fix(listener): warn when port is already in use

### DIFF
--- a/lib/listener.js
+++ b/lib/listener.js
@@ -246,7 +246,17 @@ function handleNotify(data, res) {
 }
 
 server.on("error", (err) => {
-  console.error(`Server error: ${err.message}`);
+  if (err.code === "EADDRINUSE") {
+    console.error(
+      `Error: Port ${PORT} is already in use by another process.\n` +
+        `Another service on this port will receive container traffic and may return unexpected errors (e.g. 401).\n` +
+        `Either stop the other process or use a different port:\n` +
+        `  claudeman listen -p <port>\n` +
+        `  claudeman run -e CLAUDEMAN_LISTENER_PORT=<port> ...`,
+    );
+  } else {
+    console.error(`Server error: ${err.message}`);
+  }
   process.exit(1);
 });
 

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -23,8 +23,8 @@ import http from "http";
 
 // Parse args: flags first, then positional
 const args = process.argv.slice(2);
-let HOST = "host.containers.internal";
-let port = 8080;
+let HOST = process.env.CLAUDEMAN_LISTENER_HOST || "host.containers.internal";
+let port = parseInt(process.env.CLAUDEMAN_LISTENER_PORT || "8080", 10);
 const positional = [];
 
 for (let i = 0; i < args.length; i++) {


### PR DESCRIPTION
When another service occupies the listener port, containers silently send traffic to the wrong process (e.g. getting 401 from an unrelated service). Detect EADDRINUSE and show actionable steps: stop the conflicting process or use a different port with both listen and run.