### PR TITLE
fix(ui): normalize line endings in devcontainer up output

### DIFF
--- a/commands/migrate.js
+++ b/commands/migrate.js
@@ -13,7 +13,7 @@ import {
   ensureProfileDir,
   promptYN,
 } from "../helpers/settings.js";
-import { loadDevcontainerFiles } from "../helpers/devcontainer.js";
+import { loadDevcontainerFiles, devcontainerUp } from "../helpers/devcontainer.js";
 import { mergeHooks } from "../lib/merge-hooks.js";
 import {
   getSettingsPaths,
@@ -463,14 +463,16 @@ async function installPluginInContainer(plugin, workspaceFolder) {
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 
     console.log("  Starting container...");
-    const upResult = execSync(
-      `"${DEVCONTAINER_CLI}" up --docker-path ${CONTAINER_RUNTIME} --workspace-folder "${workspaceFolder}" --config "${configPath}"`,
-      {
-        cwd: workspaceFolder,
-        encoding: "utf8",
-        stdio: ["inherit", "pipe", "inherit"],
-      },
-    );
+    const upArgs = [
+      "up",
+      "--docker-path",
+      CONTAINER_RUNTIME,
+      "--workspace-folder",
+      workspaceFolder,
+      "--config",
+      configPath,
+    ];
+    const upResult = await devcontainerUp(DEVCONTAINER_CLI, upArgs, workspaceFolder);
 
     try {
       containerId = JSON.parse(upResult).containerId;

--- a/commands/run.js
+++ b/commands/run.js
@@ -13,6 +13,7 @@ import {
 import {
   getTerminalId,
   loadDevcontainerFiles,
+  devcontainerUp,
 } from "../helpers/devcontainer.js";
 import { mergeHooks, removeHooks } from "../lib/merge-hooks.js";
 
@@ -295,11 +296,7 @@ async function runDevcontainer(
     console.log("Starting devcontainer...\n");
 
     // Run devcontainer up and capture output for container ID
-    const upResult = execSync(`"${DEVCONTAINER_CLI}" ${upArgs.join(" ")}`, {
-      cwd: workspaceFolder,
-      encoding: "utf8",
-      stdio: ["inherit", "pipe", "inherit"],
-    });
+    const upResult = await devcontainerUp(DEVCONTAINER_CLI, upArgs, workspaceFolder);
 
     // Parse container ID from output (JSON format)
     try {

--- a/helpers/devcontainer.js
+++ b/helpers/devcontainer.js
@@ -2,7 +2,7 @@ import https from "https";
 import fs from "fs";
 import path from "path";
 import os from "os";
-import { execSync } from "child_process";
+import { execSync, spawn } from "child_process";
 import { VERSION, PATCHES_DIR } from "./settings.js";
 
 export function fetchUrl(url) {
@@ -75,6 +75,38 @@ export function getTerminalId() {
 //   fs.writeFileSync(path.join(dir, "init-firewall.sh"), firewall);
 //   return { dir, configRaw };
 // }
+
+// Run `devcontainer up` capturing stdout (JSON result) while streaming
+// stderr with normalized line endings to prevent staircase output from
+// the postStartCommand.
+export function devcontainerUp(cli, args, cwd) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(cli, args, {
+      cwd,
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+
+    proc.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on("data", (data) => {
+      process.stderr.write(data.toString().replace(/\r?\n/g, "\r\n"));
+    });
+
+    proc.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`devcontainer up failed with exit code ${code}`));
+      } else {
+        resolve(stdout);
+      }
+    });
+
+    proc.on("error", reject);
+  });
+}
 
 // Temporarily using local patched files (fork DMCA'd).
 export function loadDevcontainerFiles() {


### PR DESCRIPTION
Fixes https://github.com/scottrigby/claudeman/issues/18

The postStartCommand output from init-firewall.sh inside the container emits only \n line endings. When streamed through inherited stderr, this causes a staircase effect in the terminal. Extract a shared devcontainerUp() helper that pipes stderr and normalizes \r?\n → \r\n.