### PR TITLE
fix: move .bash_history from project scope to user scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .claude
+.claude-config
 node_modules

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -89,7 +89,7 @@ causing plugins and hooks to appear duplicated.
 **Mounts:**
 
 - `PWD/.claude-config/` → `/workspace/.claude-config/` (auth + plugins cache)
-- `PWD/.claude/.bash_history` → `/commandhistory/.bash_history`
+- `PWD/.claude-config/.bash_history` → `/commandhistory/.bash_history`
 - `PWD/` → `/workspace/` (upstream workspaceMount — covers `.claude/` + source)
 
 Note: claudeman's own `--scope global` (host `~/.config/claudeman/`) is for

--- a/commands/migrate.js
+++ b/commands/migrate.js
@@ -13,7 +13,11 @@ import {
   ensureProfileDir,
   promptYN,
 } from "../helpers/settings.js";
-import { loadDevcontainerFiles, devcontainerUp } from "../helpers/devcontainer.js";
+import {
+  loadDevcontainerFiles,
+  ensureHistoryFile,
+  devcontainerUp,
+} from "../helpers/devcontainer.js";
 import { mergeHooks } from "../lib/merge-hooks.js";
 import {
   getSettingsPaths,
@@ -416,8 +420,10 @@ async function installPluginInContainer(plugin, workspaceFolder) {
 
   const claudeDir = path.join(workspaceFolder, ".claude");
   if (!fs.existsSync(claudeDir)) fs.mkdirSync(claudeDir, { recursive: true });
-  const historyFile = path.join(claudeDir, ".bash_history");
-  if (!fs.existsSync(historyFile)) fs.writeFileSync(historyFile, "");
+  const claudeConfigDir = path.join(workspaceFolder, ".claude-config");
+  if (!fs.existsSync(claudeConfigDir))
+    fs.mkdirSync(claudeConfigDir, { recursive: true });
+  const historyFile = ensureHistoryFile(claudeConfigDir, claudeDir);
 
   let containerId = null;
   let devcontainerDir = null;

--- a/commands/run.js
+++ b/commands/run.js
@@ -13,6 +13,7 @@ import {
 import {
   getTerminalId,
   loadDevcontainerFiles,
+  ensureHistoryFile,
   devcontainerUp,
 } from "../helpers/devcontainer.js";
 import { mergeHooks, removeHooks } from "../lib/merge-hooks.js";
@@ -126,11 +127,10 @@ async function runDevcontainer(
       fs.writeFileSync(gitignorePath, ".claude-config\n");
     }
 
-    // Ensure .bash_history exists (bind mount requires existing file)
-    const historyFile = path.join(claudeDir, ".bash_history");
-    if (!fs.existsSync(historyFile)) {
-      fs.writeFileSync(historyFile, "");
-    }
+    // Ensure .bash_history exists (bind mount requires existing file).
+    // Stored in .claude-config (user scope, gitignored) rather than .claude
+    // (project scope) since history may contain sensitive input.
+    const historyFile = ensureHistoryFile(claudeConfigDir, claudeDir);
 
     // Merge profile hooks into project-scope settings.json (removed on exit)
     if (profile.hooks) {

--- a/helpers/devcontainer.js
+++ b/helpers/devcontainer.js
@@ -76,6 +76,25 @@ export function getTerminalId() {
 //   return { dir, configRaw };
 // }
 
+// Ensure .bash_history exists at the user-scope location (.claude-config/).
+// v2.0.0 stored this in .claude/ (project scope); as of v2.0.1 it is moved
+// to .claude-config/ (user scope, gitignored) to avoid exposing sensitive
+// command history. This move code must remain for backwards compatibility
+// through v2.
+// Returns the history file path for use in bind mounts.
+export function ensureHistoryFile(claudeConfigDir, claudeDir) {
+  const historyFile = path.join(claudeConfigDir, ".bash_history");
+  if (!fs.existsSync(historyFile)) {
+    const oldHistoryFile = path.join(claudeDir, ".bash_history");
+    if (fs.existsSync(oldHistoryFile)) {
+      fs.renameSync(oldHistoryFile, historyFile);
+    } else {
+      fs.writeFileSync(historyFile, "");
+    }
+  }
+  return historyFile;
+}
+
 // Run `devcontainer up` capturing stdout (JSON result) while streaming
 // stderr with normalized line endings to prevent staircase output from
 // the postStartCommand.

--- a/test/helpers/devcontainer.test.js
+++ b/test/helpers/devcontainer.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import { createFixture } from "./temp-dir.js";
+import { ensureHistoryFile } from "../../helpers/devcontainer.js";
+
+describe("ensureHistoryFile", () => {
+  let fixture;
+  let claudeConfigDir;
+  let claudeDir;
+
+  beforeEach(() => {
+    fixture = createFixture();
+    claudeConfigDir = path.join(fixture.dir, ".claude-config");
+    claudeDir = path.join(fixture.dir, ".claude");
+    fs.mkdirSync(claudeConfigDir, { recursive: true });
+    fs.mkdirSync(claudeDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  it("creates empty file when no history exists", () => {
+    const result = ensureHistoryFile(claudeConfigDir, claudeDir);
+
+    expect(result).toBe(path.join(claudeConfigDir, ".bash_history"));
+    expect(fs.existsSync(result)).toBe(true);
+    expect(fs.readFileSync(result, "utf8")).toBe("");
+  });
+
+  it("moves from old location when it exists", () => {
+    const oldHistory = path.join(claudeDir, ".bash_history");
+    fs.writeFileSync(oldHistory, "ls -la\nnpm test\n");
+
+    const result = ensureHistoryFile(claudeConfigDir, claudeDir);
+
+    expect(fs.readFileSync(result, "utf8")).toBe("ls -la\nnpm test\n");
+    expect(fs.existsSync(oldHistory)).toBe(false);
+  });
+
+  it("does not overwrite existing file at new location", () => {
+    const newHistory = path.join(claudeConfigDir, ".bash_history");
+    fs.writeFileSync(newHistory, "existing history\n");
+    const oldHistory = path.join(claudeDir, ".bash_history");
+    fs.writeFileSync(oldHistory, "old history\n");
+
+    const result = ensureHistoryFile(claudeConfigDir, claudeDir);
+
+    expect(fs.readFileSync(result, "utf8")).toBe("existing history\n");
+  });
+});


### PR DESCRIPTION
Container bash history was stored in .claude/ (project scope, committable), risking exposure of sensitive command history. Move to .claude-config/ (user scope, gitignored). Existing history is copied forward on first run (backwards-compatible through v2).

- Extract ensureHistoryFile() helper in helpers/devcontainer.js
- Update ARCHITECTURE.md mount documentation
- Add unit tests for history file migration scenarios

Fixes scottrigby/claudeman#20