### PR TITLE
feat: add --no-firewall flag for development-only

### DIFF
--- a/commands/run.js
+++ b/commands/run.js
@@ -25,6 +25,7 @@ async function runDevcontainer(
   extraDomains = [],
   localDevcontainerDir = null,
   envVars = [],
+  noFirewall = false,
 ) {
   // Check for container runtime
   if (!CONTAINER_RUNTIME) {
@@ -180,6 +181,9 @@ async function runDevcontainer(
     const uniqueDomains = [...new Set(allExtraDomains)];
     if (uniqueDomains.length > 0) {
       process.env.WHITELIST_DOMAINS = uniqueDomains.join(" ");
+    }
+    if (noFirewall) {
+      process.env.CLAUDEMAN_NO_FIREWALL = "1";
     }
 
     let upstreamConfigRaw;
@@ -358,6 +362,7 @@ export const runCmd = new Command("run")
     (v) => v.split(",").filter(Boolean),
   )
   .option("--devcontainer-dir <path>", "Local devcontainer files")
+  .option("--no-firewall", "Disable network firewall (development only)")
   .option(
     "--env <KEY=VALUE>",
     "Set environment variable in container (repeatable)",
@@ -370,6 +375,7 @@ export const runCmd = new Command("run")
     const extraDomains = opts.extraDomains || [];
     const devcontainerDir = opts.devcontainerDir || null;
     const envVars = opts.env || [];
+    const noFirewall = opts.firewall === false;
     await runDevcontainer(
       profileName,
       workspaceFolder,
@@ -377,5 +383,6 @@ export const runCmd = new Command("run")
       extraDomains,
       devcontainerDir,
       envVars,
+      noFirewall,
     );
   });

--- a/patches/.devcontainer/devcontainer.json
+++ b/patches/.devcontainer/devcontainer.json
@@ -49,10 +49,11 @@
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
     "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
-    "WHITELIST_DOMAINS": "${localEnv:WHITELIST_DOMAINS:}"
+    "WHITELIST_DOMAINS": "${localEnv:WHITELIST_DOMAINS:}",
+    "CLAUDEMAN_NO_FIREWALL": "${localEnv:CLAUDEMAN_NO_FIREWALL:}"
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
-  "postStartCommand": "sudo WHITELIST_DOMAINS=\"$WHITELIST_DOMAINS\" /usr/local/bin/init-firewall.sh",
+  "postStartCommand": "if [ \"$CLAUDEMAN_NO_FIREWALL\" = \"1\" ]; then echo 'Firewall disabled (--no-firewall)'; else sudo WHITELIST_DOMAINS=\"$WHITELIST_DOMAINS\" /usr/local/bin/init-firewall.sh; fi",
   "waitFor": "postStartCommand"
 }


### PR DESCRIPTION
Skips the iptables firewall init script when running with --no-firewall. Useful for development workflows that need unrestricted network access (SSH to dynamic VM IPs, CMX cluster APIs, etc.). Sets CLAUDEMAN_NO_FIREWALL=1 env var which the postStartCommand checks before running init-firewall.sh.