### PR TITLE
fix: pass --progress=plain to suppress BuildKit TUI terminal corruption

### DIFF
--- a/commands/migrate.js
+++ b/commands/migrate.js
@@ -465,6 +465,11 @@ async function installPluginInContainer(plugin, workspaceFolder) {
       remoteEnv: { ...(upstreamConfig.remoteEnv || {}) },
     };
 
+    // Suppress BuildKit's animated progress TUI, which emits ANSI cursor-movement
+    // sequences that corrupt the terminal after the container starts.
+    config.build = config.build || {};
+    config.build.options = [...(config.build.options || []), "--progress=plain"];
+
     const configPath = path.join(devcontainerDir, "devcontainer.json");
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 

--- a/commands/run.js
+++ b/commands/run.js
@@ -258,6 +258,14 @@ async function runDevcontainer(
       upstreamConfig.build.args.CLAUDE_CODE_VERSION = claudeVersion;
     }
 
+    // Suppress BuildKit's animated progress TUI, which emits ANSI cursor-movement
+    // sequences that corrupt the terminal after the container starts.
+    upstreamConfig.build = upstreamConfig.build || {};
+    upstreamConfig.build.options = [
+      ...(upstreamConfig.build.options || []),
+      "--progress=plain",
+    ];
+
     const config = {
       ...upstreamConfig,
       // Merge profile features with any upstream features


### PR DESCRIPTION
BuildKit's animated progress renderer emits ANSI cursor-movement sequences that corrupt the terminal after devcontainer up completes. Injecting build.options: ["--progress=plain"] in the generated devcontainer.json switches to plain line-by-line output for both run and migrate.