### PR TITLE
build: establish npm version release process; fix package.json to 2.1.1; sign tags/commits

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+sign-git-tag=true
+sign-git-commit=true

--- a/README.md
+++ b/README.md
@@ -233,3 +233,14 @@ The bundled `go` and `full` profiles include cache settings for their respective
    ```
 
 5. **Set up notifications**: Run `claudeman init` in your project to configure notification hooks.
+
+## Releasing
+
+Releases use `npm version`, which bumps `package.json`, commits the change, and creates a git tag in one step. Pushing the tag triggers the GitHub Actions workflow, which creates the GitHub release and bumps the Homebrew formula.
+
+```bash
+npm version patch   # or minor / major, or an explicit version like 2.2.0
+git push && git push --tags
+```
+
+Do not create tags manually — `package.json` must match the tag for `claudeman --version` to report the correct version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudeman",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "type": "module",
   "scripts": {
     "test": "vitest run --project unit",


### PR DESCRIPTION
Use `npm version` as the single release trigger — it bumps package.json, commits, and creates a signed tag atomically. Pushing the tag fires the existing bump-formula workflow. Add .npmrc to enforce signed tags and commits by default. Fix package.json which was stale at 2.0.0.